### PR TITLE
Shortcut buttons plugin should not use submit buttons

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -144,6 +144,7 @@ export function ShortcutButtonsPlugin(config: ShortcutButtonsFlatpickr.Config) {
 
                 (Array.isArray(cfg.button) ? cfg.button : [cfg.button]).forEach((b, index) => {
                     const button = document.createElement('button');
+                    button.type = 'button';
                     button.classList.add('shortcut-buttons-flatpickr-button');
                     button.textContent = b.label;
                     button.dataset.index = String(index);


### PR DESCRIPTION
The Shortcut Buttons plugin creates normal buttons to confirm or delete flatpickr values. However, since the HTML standard interprets buttons as `type="submit"` by default, the buttons created by the plugin do not serve their actual purpose.

In my case the enter event on completely independent form elements was evaluated differently from what it should be.