### PR TITLE
Allow multiple classes on button attribute

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,9 @@ export function ShortcutButtonsPlugin(config: ShortcutButtonsFlatpickr.Config) {
         function setButtonsAttributes(button: HTMLButtonElement, attributes?: ShortcutButtonsFlatpickr.Attributes) {
             Object.keys(attributes).filter((attribute) => supportedAttributes.has(attribute)).forEach((key) => {
                 if (key === 'class') {
-                    button.classList.add(attributes[key]);
+                    attributes[key].split(' ').forEach((className) => {
+                        button.classList.add(className);
+                    });
                     return;
                 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,9 +122,7 @@ export function ShortcutButtonsPlugin(config: ShortcutButtonsFlatpickr.Config) {
         function setButtonsAttributes(button: HTMLButtonElement, attributes?: ShortcutButtonsFlatpickr.Attributes) {
             Object.keys(attributes).filter((attribute) => supportedAttributes.has(attribute)).forEach((key) => {
                 if (key === 'class') {
-                    attributes[key].split(' ').forEach((className) => {
-                        button.classList.add(className);
-                    });
+                    button.classList.add(...attributes[key].split(' '));
                     return;
                 }
 

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -137,7 +137,7 @@ describe('ShortcutButtonsPlugin', () => {
                 attributes: {
                     'accesskey': '1',
                     'aria-label': 'jump to test',
-                    'class': 'test-class',
+                    'class': 'test-class1 test-class2',
                     'tabindex': '-1',
                     'data-index': '1',
                 },
@@ -153,7 +153,8 @@ describe('ShortcutButtonsPlugin', () => {
 
         expect(button.getAttribute('accesskey')).to.be('1');
         expect(button.getAttribute('aria-label')).to.be('jump to test');
-        expect(button.getAttribute('class')).to.contain('test-class');
+        expect(button.getAttribute('class')).to.contain('test-class1');
+        expect(button.getAttribute('class')).to.contain('test-class2');
         expect(button.getAttribute('tabindex')).to.be('-1');
         expect(button.dataset.index).to.be('0');
 


### PR DESCRIPTION
Allow multiple classes on button attribute.
E.g.:
`{class:  'class1 class2 class3'}`