### PR TITLE
type check calendar container before calling appendChild method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,9 @@ export function ShortcutButtonsPlugin(config: ShortcutButtonsFlatpickr.Config) {
 
                 wrapper.appendChild(buttons);
 
-                fp.calendarContainer.appendChild(wrapper);
+                if (typeof fp.calendarContainer !== 'undefined') {
+                    fp.calendarContainer.appendChild(wrapper);
+                }
 
                 wrapper.addEventListener('click', onClick);
                 wrapper.addEventListener('keydown', onKeyDown);


### PR DESCRIPTION
As suggested in #21 this pull requests adds a type check to the calendarContainer before appending the wrapper as a child. Checkout my fork until @jcsmorais releases a new version: https://github.com/larshanskrause/shortcut-buttons-flatpickr