### PR TITLE
Publish JavaScript modules (ESM)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,19 +4,22 @@
   "version": "0.4.0",
   "exports": {
     "types": "./dist/types/index.d.ts",
+    "import": "./dist/esm/index.js",
     "default": "./dist/shortcut-buttons-flatpickr.js"
   },
   "main": "dist/shortcut-buttons-flatpickr.js",
+  "module": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "run-s build:pre build:dev build:prod",
     "build:pre": "rm -rf dist && mkdir -p dist/themes",
     "build:dev": "run-s build:ts:dev build:themes:dev",
-    "build:prod": "run-s build:ts:prod build:types build:themes:prod",
+    "build:prod": "run-s build:ts:prod build:esm build:types build:themes:prod",
     "build:ts:dev": "webpack --config build/webpack.config.ts --mode development",
     "build:ts:prod": "webpack --config build/webpack.config.ts --mode production",
     "build:themes:dev": "webpack --config build/webpack.themes.ts --mode development",
     "build:themes:prod": "webpack --config build/webpack.themes.ts --mode production",
+    "build:esm": "tsc -p tsconfig.esm.json",
     "build:types": "tsc -p tsconfig.declarations.json",
     "prepublishOnly": "run-s build test",
     "start:server": "forever start -m 1 -c ts-node tests/server.ts",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
   "name": "shortcut-buttons-flatpickr",
   "description": "Shortcut buttons is a plugin for flatpickr that provides users an alternative way to interact with the datetime picker.",
   "version": "0.4.0",
+  "exports": {
+    "types": "./dist/types/index.d.ts",
+    "default": "./dist/shortcut-buttons-flatpickr.js"
+  },
   "main": "dist/shortcut-buttons-flatpickr.js",
+  "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "run-s build:pre build:dev build:prod",
     "build:pre": "rm -rf dist && mkdir -p dist/themes",

--- a/tsconfig.declarations.json
+++ b/tsconfig.declarations.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "declaration": true,
         "emitDeclarationOnly": true,
+        "declarationMap": true,
         "outDir": "./dist/types",
         "removeComments": true
     },

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "es6",
+    "outDir": "dist/esm"
+  },
+  "extends": "./tsconfig.json",
+  "include": [
+    "./src/index.ts"
+  ]
+}


### PR DESCRIPTION
ESM module are published unminified by convention.
Therefore they can simply be build by `tsc`.

Also the TypeScript declaration files are linked via package.json now. TypeScript needs the `types` (with node10 module resolution) or `exports.types` (with node16 module resolution) to be defined in order for declarations to actually be picked up, otherwise the following error would be emitted:

```   
Cannot find module 'shortcut-buttons-flatpickr' or its corresponding type declarations.
```

Additionally declaration mappings are published so Language Services can understand these map files and use them to map declaration-file based definition locations to their original source, when available.
See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-9.html#new---declarationmap